### PR TITLE
Github Workflow for building site with pandoc and pushing output to repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: pages-build-deployment
+
+on: push
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+      
+      - uses: docker://pandoc/core:2.9
+        with:
+          args: "-f markdown-smart+autolink_bare_uris --template index.tmpl index.md -o index.html"
+      
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        with:
+          branch: master # The branch the action should deploy to.
+          folder: . # The folder the action should deploy.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 README.html
 .*
 _*
+!.github


### PR DESCRIPTION
Automatically prioritized over GitHub-actions bot, this will run pandoc and then commit it to the repo. 

Example: https://dustinknopoff.github.io/plaintextaccounting.github.io/

First pass at #18 