### PR TITLE
Add beanhub open source tools

### DIFF
--- a/index.md
+++ b/index.md
@@ -458,7 +458,8 @@ Additional helper tools complementing the PTA apps, by category.
 - [beancount-parser](https://github.com/LaunchPlatform/beancount-parser) standalone Lark based beancount syntax parser (not relying on the beancount library)
 
 ### Utilities
-- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) Command line tools for BeanHub users but also comes with features like a [custom form](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/) web app for non-BeanHub users
+
+- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) command line tools for BeanHub users but also comes with features like a [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/) web app for non-BeanHub users
 
 ### API
 
@@ -467,6 +468,7 @@ Additional helper tools complementing the PTA apps, by category.
 - [hledger-web](https://github.com/simonmichael/hledger/tree/master/hledger-web) the web app includes a JSON API server for *ledger files (haskell)
 - [ledgerhelpers](https://github.com/Rudd-O/ledgerhelpers) extends Ledger's python library (python)
 - [node-hledger](https://github.com/rstacruz/node-hledger) Node.js API for *ledger files (javascript)
+- [BeanHub API](https://api.beanhub.io/redoc) proprietary SaaS API for operating beancount and [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/)
 
 <!--
 other console/curses tools

--- a/index.md
+++ b/index.md
@@ -457,6 +457,9 @@ Additional helper tools complementing the PTA apps, by category.
 
 - [beancount-parser](https://github.com/LaunchPlatform/beancount-parser) standalone Lark based beancount syntax parser (not relying on the beancount library)
 
+### Utilities
+- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) Command line tools for BeanHub users but also comes with features like a [custom form](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/) web app for non-BeanHub users
+
 ### API
 
 - [gledger](https://github.com/gledger/gledger) Go package to interface with Ledger (go)

--- a/index.md
+++ b/index.md
@@ -377,6 +377,10 @@ Additional helper tools complementing the PTA apps, by category.
 - [reorder-journal.sh](https://github.com/amitaibu/hledger-example/blob/master/reorder-journal.sh) sort hledger entries, preserving directives/comments at top of file (bash)
 - [sassetti](https://github.com/jvasile/sassetti) adds lisp macros to ledger files (common lisp)
 
+### Formatting
+
+- [beancount-black](https://github.com/LaunchPlatform/beancount-black) opinionated beancount file formatter
+
 ### Reporting
 
 - [budget_report](https://github.com/sulemankm/budget_report) budget reporting with beancount (python)
@@ -448,6 +452,10 @@ Additional helper tools complementing the PTA apps, by category.
 - [cone](https://f-droid.org/en/packages/info.tangential.cone/) data entry app for the h/ledger format (Android, [dart](https://github.com/bradyt/cone))
 - [MoLe](https://fossdroid.com/a/mole.html) mobile client for hledger-web (Android, [java](https://git.ktnx.net/?p=mobile-ledger.git))
 - [hledger.org: Mobile apps](https://hledger.org/mobile.html)
+
+### Library
+
+- [beancount-parser](https://github.com/LaunchPlatform/beancount-parser) standalone Lark based beancount syntax parser (not relying on the beancount library)
 
 ### API
 

--- a/index.md
+++ b/index.md
@@ -456,8 +456,8 @@ Additional helper tools complementing the PTA apps, by category.
 
 ### Library
 
-- [beancount-parser](https://github.com/LaunchPlatform/beancount-parser) standalone Lark based beancount syntax parser (not relying on the beancount library)
-- [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms) core library provides data types and processors of custom forms for inputing repeating similar entries easily
+- [beancount-parser](https://github.com/LaunchPlatform/beancount-parser) standalone [Lark-based](https://github.com/lark-parser/lark) beancount syntax parser (not relying on the beancount library)
+- [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms) a library provides data types and processors of custom beancount forms for inputting repeating similar entries easily
 - [beanhub-web-react](https://github.com/LaunchPlatform/beanhub-web-react) react components for beancount entry input forms and [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms)
 
 ### Utilities

--- a/index.md
+++ b/index.md
@@ -457,7 +457,7 @@ Additional helper tools complementing the PTA apps, by category.
 ### Library
 
 - [beancount-parser](https://github.com/LaunchPlatform/beancount-parser) standalone Lark based beancount syntax parser (not relying on the beancount library)
-- [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms) core library for the data types and processor of [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms)
+- [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms) core library provides data types and processors of custom forms for inputing repeating similar entries easily
 - [beanhub-web-react](https://github.com/LaunchPlatform/beanhub-web-react) react components for beancount entry input forms and [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms)
 
 ### Utilities
@@ -471,7 +471,7 @@ Additional helper tools complementing the PTA apps, by category.
 - [hledger-web](https://github.com/simonmichael/hledger/tree/master/hledger-web) the web app includes a JSON API server for *ledger files (haskell)
 - [ledgerhelpers](https://github.com/Rudd-O/ledgerhelpers) extends Ledger's python library (python)
 - [node-hledger](https://github.com/rstacruz/node-hledger) Node.js API for *ledger files (javascript)
-- [BeanHub API](https://api.beanhub.io/redoc) proprietary SaaS API for operating hosted beancount and [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms)
+- [BeanHub API](https://api.beanhub.io/redoc) proprietary SaaS API for operating on hosted beancount repositories and [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms)
 
 <!--
 other console/curses tools

--- a/index.md
+++ b/index.md
@@ -458,10 +458,11 @@ Additional helper tools complementing the PTA apps, by category.
 
 - [beancount-parser](https://github.com/LaunchPlatform/beancount-parser) standalone Lark based beancount syntax parser (not relying on the beancount library)
 - [beancount-forms](https://github.com/LaunchPlatform/beanhub-forms) core library for the data types and processor of [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/)
+- [beanhub-web-react](https://github.com/LaunchPlatform/beanhub-web-react) react components for beancount entry input forms and [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/)
 
 ### Utilities
 
-- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) command line tools comes with features like formatter and [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/) web app
+- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) beancount command line tools comes with features like formatter and a [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/) web app
 
 ### API
 

--- a/index.md
+++ b/index.md
@@ -380,6 +380,7 @@ Additional helper tools complementing the PTA apps, by category.
 ### Formatting
 
 - [beancount-black](https://github.com/LaunchPlatform/beancount-black) opinionated beancount file formatter
+- [beancount-black web app](https://app.beanhub.io/tools/beancount-formatter) opinionated beancount file formatter but as a web based app
 
 ### Reporting
 
@@ -456,10 +457,11 @@ Additional helper tools complementing the PTA apps, by category.
 ### Library
 
 - [beancount-parser](https://github.com/LaunchPlatform/beancount-parser) standalone Lark based beancount syntax parser (not relying on the beancount library)
+- [beancount-forms](https://github.com/LaunchPlatform/beanhub-forms) core library for the data types and processor of [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/)
 
 ### Utilities
 
-- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) command line tools for BeanHub users but also comes with features like a [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/) web app for non-BeanHub users
+- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) command line tools comes with features like formatter and [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/) web app
 
 ### API
 

--- a/index.md
+++ b/index.md
@@ -462,7 +462,7 @@ Additional helper tools complementing the PTA apps, by category.
 
 ### Utilities
 
-- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) beancount command line tools comes with features like formatter and a [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms) web app
+- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) beancount command line tools come with features like formatter and a [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms) web app
 
 ### API
 
@@ -471,7 +471,7 @@ Additional helper tools complementing the PTA apps, by category.
 - [hledger-web](https://github.com/simonmichael/hledger/tree/master/hledger-web) the web app includes a JSON API server for *ledger files (haskell)
 - [ledgerhelpers](https://github.com/Rudd-O/ledgerhelpers) extends Ledger's python library (python)
 - [node-hledger](https://github.com/rstacruz/node-hledger) Node.js API for *ledger files (javascript)
-- [BeanHub API](https://api.beanhub.io/redoc) proprietary SaaS API for operating beancount and [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms)
+- [BeanHub API](https://api.beanhub.io/redoc) proprietary SaaS API for operating hosted beancount and [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms)
 
 <!--
 other console/curses tools

--- a/index.md
+++ b/index.md
@@ -457,12 +457,12 @@ Additional helper tools complementing the PTA apps, by category.
 ### Library
 
 - [beancount-parser](https://github.com/LaunchPlatform/beancount-parser) standalone Lark based beancount syntax parser (not relying on the beancount library)
-- [beancount-forms](https://github.com/LaunchPlatform/beanhub-forms) core library for the data types and processor of [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/)
-- [beanhub-web-react](https://github.com/LaunchPlatform/beanhub-web-react) react components for beancount entry input forms and [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/)
+- [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms) core library for the data types and processor of [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms)
+- [beanhub-web-react](https://github.com/LaunchPlatform/beanhub-web-react) react components for beancount entry input forms and [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms)
 
 ### Utilities
 
-- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) beancount command line tools comes with features like formatter and a [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/) web app
+- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) beancount command line tools comes with features like formatter and a [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms) web app
 
 ### API
 
@@ -471,7 +471,7 @@ Additional helper tools complementing the PTA apps, by category.
 - [hledger-web](https://github.com/simonmichael/hledger/tree/master/hledger-web) the web app includes a JSON API server for *ledger files (haskell)
 - [ledgerhelpers](https://github.com/Rudd-O/ledgerhelpers) extends Ledger's python library (python)
 - [node-hledger](https://github.com/rstacruz/node-hledger) Node.js API for *ledger files (javascript)
-- [BeanHub API](https://api.beanhub.io/redoc) proprietary SaaS API for operating beancount and [BeanHub Forms](https://beanhub.io/blog/2023/07/31/automating-beancount-data-input-with-beanhub-custom-forms/)
+- [BeanHub API](https://api.beanhub.io/redoc) proprietary SaaS API for operating beancount and [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms)
 
 <!--
 other console/curses tools

--- a/index.md
+++ b/index.md
@@ -380,7 +380,7 @@ Additional helper tools complementing the PTA apps, by category.
 ### Formatting
 
 - [beancount-black](https://github.com/LaunchPlatform/beancount-black) opinionated beancount file formatter
-- [beancount-black web app](https://app.beanhub.io/tools/beancount-formatter) opinionated beancount file formatter but as a web based app
+- [beancount-black web app](https://app.beanhub.io/tools/beancount-formatter) opinionated beancount file formatter as a web-based app
 
 ### Reporting
 


### PR DESCRIPTION
I open-sourced a tons of tools we built for BeanHub and would like to update the page. Sorry some of the tools I built not sure which categories it belongs to, such as formatter, library or beanhub-cli. So I added a few sections. Please feel free to let me know if you think there are better way to categorize them, or if you folks feel some of those open-sourced tools shouldn't be included in the list such as libraries.