### PR TITLE
Add beanhub-extract and beanhub-import

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -531,6 +531,8 @@ Commit activity (from https://hledger.org/reporting-version-control-stats.html)
 - [total_recall](https://github.com/eval/total_recall) CSV to *ledger converter
 - [ynab-to-ledger](https://github.com/vermiceli/ynab-to-ledger) You Need A Budget (YNAB) to *ledger converter. Handles multiple currencies, multiple number formats, reconciliation, memos, transfers, and split transactions
 - [ynab_to_ledger](https://github.com/pgr0ss/ynab_to_ledger) You Need A Budget to *ledger converter
+- [beanhub-extract](https://github.com/LaunchPlatform/beanhub-extract) Simple Python library for extracting all kinds of bank export CSV files into standardized transaction data objects
+- [beanhub-import](https://github.com/LaunchPlatform/beanhub-import) Declarative idempotent rule-based beancount transaction import engine in Python consumes data extracted by [beanhub-extract](https://github.com/LaunchPlatform/beanhub-extract)
 
 ### Price fetching
 

--- a/src/index.md
+++ b/src/index.md
@@ -663,7 +663,7 @@ Commit activity (from https://hledger.org/reporting-version-control-stats.html)
 
 ### Utilities
 
-- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) beancount command line tools come with features like formatter and a [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms) web app
+- [beanhub-cli](https://github.com/LaunchPlatform/beanhub-cli) beancount command line tools come with features like formatter, [beanhub-import](https://github.com/LaunchPlatform/beancount-import) and a [beanhub-forms](https://github.com/LaunchPlatform/beanhub-forms) web app
 
 ### API
 


### PR DESCRIPTION
I just published two open source projects.

https://github.com/LaunchPlatform/beanhub-import

https://github.com/LaunchPlatform/beanhub-extract

They are for importing CSV files based on declarative rules defined in a simple YAML file. The import result is idempotent as I insert unique import id from the CSV files. I use my [beancount-parser](https://github.com/LaunchPlatform/beancount-parser) to parse the tree of existing beancount files to learn where are those transactions, and find out how to change them to make to up-to-date.

You can read the how-it-works section if you are interested in learning more

https://github.com/LaunchPlatform/beanhub-import?tab=readme-ov-file#how-it-works