### PR TITLE
Add favagtk, clarify GUI as 'desktop' apps

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -933,13 +933,14 @@ td:first-child strong a {
 - [puffin](https://github.com/siddhantac/puffin) TUI for hledger browsing (go)
 - [regdel](https://github.com/guillaumechereau/regdel) TUI for browsing Ledger files (python)
 
-### UI, GUI
+### UI, desktop GUI
 
 - [fruit-credits](https://codeberg.org/dz4k/fruit-credits) data entry/reporting GUI for hledger (Vala, GNOME)
 - [ledgerble](https://github.com/sbridges/ledgerble) reporting GUI with charts & adjustable reports (Javascript)
 - [ledgerhelpers](https://github.com/Rudd-O/ledgerhelpers) misc. GUI tools + helper library (Python, GTK)
 - [Prudent][prudent] integrated journal editing/importing/reporting GUI for Ledger (Javascript, mac only, closed source)
 - [hledger-web-rs](https://gitlab.com/shivjm/hledger-web-rs) reporting GUI (rust)
+- [favagtk](https://gitlab.gnome.org/johannesjh/favagtk/) app of Fava web UI for beancount browsing (Linux, GTK)
 
 ### UI, web
 


### PR DESCRIPTION
Adding favagtk which is under active development and recently got updated to version 1.0.

(Open to adding my app https://github.com/seltzered/beancolage too if appropriate, I consider it still rather early stage but am trying to work on it more again)