### PR TITLE
Resolve 404 on non-profit accounting page.

### DIFF
--- a/src/Non-profit-accounting.md
+++ b/src/Non-profit-accounting.md
@@ -2,5 +2,5 @@
 
 Also known as https://en.wikipedia.org/wiki/Fund_accounting.
 
-- [Non-Profit Accounting With Ledger CLI, A Tutorial](https://k.sfconservancy.org/NPO-Accounting/npo-ledger-cli/files/9f2a0cd1cc1bdeaec128e69a4b4c39687cb2c8c7/npo-ledger-cli-tutorial.md)
+- [Non-Profit Accounting With Ledger CLI, A Tutorial](https://f.sfconservancy.org/NPO-Accounting/npo-ledger-cli/src/branch/master/npo-ledger-cli-tutorial.md)
 - https://www.youtube.com/@Aplos


### PR DESCRIPTION
This fixes a broken link.