### PR TITLE
Remove white-space:nowrap from headings for better readability

### DIFF
--- a/out/css/site.css
+++ b/out/css/site.css
@@ -17,7 +17,6 @@ h6 { font-size: 1.5rem; }
 
 h1, h2, h3, h4, h5, h6 {
     font-weight:bold;
-    white-space:nowrap;
     text-shadow: 1px 1px 2px white;
 }
 


### PR DESCRIPTION
Remove `white-space:nowrap` from headings (originally added in 1276fa699f9f296ca6412f06108075b57794ebb3), which hurts readability on smaller screens, especially mobile. See examples below.

Nowrap:
<img src="https://github.com/user-attachments/assets/a661ca6c-0ca5-488a-986a-80fae402dc6d" width=250>

Normal:
<img src="https://github.com/user-attachments/assets/104665a8-5421-44fc-acfe-cb2067df0fa9" width=250>
